### PR TITLE
bugfix: always calling wake leads to an unnecessary busy loop

### DIFF
--- a/src/tee.rs
+++ b/src/tee.rs
@@ -116,16 +116,6 @@ impl<T> Stream for Tee<T> {
             }
         }
 
-        match Pin::new(&mut self.stream).poll_next(cx) {
-            Ready(Some(output)) => {
-                cx.waker().clone().wake();
-                Ready(Some(output))
-            }
-            Ready(None) => Ready(None),
-            Pending => {
-                cx.waker().clone().wake();
-                Pending
-            }
-        }
+        Pin::new(&mut self.stream).poll_next(cx)
     }
 }


### PR DESCRIPTION
I'm pretty sure these calls to `wake` are spurious, as the underlying flume receiver will call `wake` correctly when we poll it. In my tokio application, I can observe that these calls lead to busyloops — `tee`s constantly end up having their `poll_next` method called uselessly.

Tests pass under both runtimes.