### PR TITLE
remove dependency on syn 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ num_cpus = "1.13.1"
 async-std = { version = "1.10.0", features = ["unstable"], optional = true }
 tokio = { version = "1.16.1", features = ["sync", "macros", "time"] }
 pin-project = "1.0.10"
-derivative = "2.2.0"
 by_address = "1.0.4"
 flume = "0.10.10"
 once_cell = "1.9.0"
 dashmap = "5.1.0"
 crossbeam = "0.8.1"
 parking_lot = "0.12.0"
+educe = { version = "0.5.9", default-features = false, features = ["Debug", "PartialEq", "Eq", "PartialOrd", "Ord"] }
 
 [dev-dependencies]
 tokio = { version = "1.16.1", features = ["sync", "macros", "rt-multi-thread", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rand = "0.8.4"
 async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
 itertools = "0.12"
 concurrent-slice = "0.1.0"
-structopt = "0.3.26"
+clap = { version = "4", features = ["derive"] }
 
 [features]
 runtime-async-std = ["async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-std = { version = "1.10.0", features = ["unstable"], optional = true }
 tokio = { version = "1.16.1", features = ["sync", "macros", "time"] }
 pin-project = "1.0.10"
 by_address = "1.0.4"
-flume = "0.10.10"
+flume = "0.11"
 once_cell = "1.9.0"
 dashmap = "5.1.0"
 crossbeam = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ educe = { version = "0.5.9", default-features = false, features = ["Debug", "Par
 tokio = { version = "1.16.1", features = ["sync", "macros", "rt-multi-thread", "time"] }
 rand = "0.8.4"
 async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
-itertools = "0.10.3"
+itertools = "0.12"
 concurrent-slice = "0.1.0"
 structopt = "0.3.26"
 

--- a/examples/shared_stream.rs
+++ b/examples/shared_stream.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use futures::{
     future,
     stream::{self, StreamExt as _},
@@ -5,22 +6,21 @@ use futures::{
 use par_stream::{rt, Shared};
 use rand::{prelude::*, rngs::OsRng};
 use std::time::Duration;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-struct Opts {
+#[derive(Parser)]
+struct Cli {
     pub num_jobs: usize,
     pub num_workers: usize,
     pub in_buf_size: usize,
     pub out_buf_size: usize,
     pub pow: u32,
-    #[structopt(long)]
+    #[arg(long)]
     pub spawn: bool,
 }
 
 fn main() {
     par_stream::rt::block_on_executor(async move {
-        let opts = Opts::from_args();
+        let opts = Cli::parse();
 
         let elapsed_notifier = shared_stream_by_notifier_test(&opts).await;
         println!("elapsed for notifier\t{:?}ms", elapsed_notifier.as_millis());
@@ -30,7 +30,7 @@ fn main() {
     });
 }
 
-async fn shared_stream_by_notifier_test(opts: &Opts) -> Duration {
+async fn shared_stream_by_notifier_test(opts: &Cli) -> Duration {
     let pow = opts.pow;
     let spawn = opts.spawn;
 
@@ -66,7 +66,7 @@ async fn shared_stream_by_notifier_test(opts: &Opts) -> Duration {
     instant.elapsed()
 }
 
-async fn shared_stream_by_channel_test(opts: &Opts) -> Duration {
+async fn shared_stream_by_channel_test(opts: &Cli) -> Duration {
     let pow = opts.pow;
     let spawn = opts.spawn;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,5 @@
 pub use by_address::ByAddress;
-pub use derivative::Derivative;
+pub use educe::Educe;
 pub use futures::{
     future::{self, BoxFuture, Either, FutureExt as _},
     join, ready,

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -243,12 +243,12 @@ mod sync {
     use super::*;
     use std::{cmp::Reverse, collections::BinaryHeap};
 
-    #[derive(Derivative)]
-    #[derivative(PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Educe)]
+    #[educe(PartialEq, Eq, PartialOrd, Ord)]
     struct KV<K, V> {
         pub key: K,
         pub index: usize,
-        #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
+        #[educe(PartialEq(ignore), PartialOrd(ignore))]
         pub value: V,
     }
 
@@ -378,12 +378,12 @@ mod try_sync {
     use super::*;
     use std::{cmp::Reverse, collections::BinaryHeap};
 
-    #[derive(Derivative)]
-    #[derivative(PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Educe)]
+    #[educe(PartialEq, Eq, PartialOrd, Ord)]
     struct KV<K, V> {
         pub key: K,
         pub index: usize,
-        #[derivative(PartialEq = "ignore", PartialOrd = "ignore", Ord = "ignore")]
+        #[educe(PartialEq(ignore), PartialOrd(ignore))]
         pub value: V,
     }
 

--- a/src/index_stream.rs
+++ b/src/index_stream.rs
@@ -70,8 +70,8 @@ mod reorder_enumerated {
     use super::*;
 
     /// Stream for the [reorder_enumerated](IndexStreamExt::reorder_enumerated) method.
-    #[derive(Derivative)]
-    #[derivative(Debug)]
+    #[derive(Educe)]
+    #[educe(Debug(bound(T: Debug)))]
     #[pin_project]
     pub struct ReorderEnumerated<S, T>
     where
@@ -79,6 +79,7 @@ mod reorder_enumerated {
     {
         pub(super) commit: usize,
         pub(super) buffer: HashMap<usize, T>,
+        #[educe(Debug(ignore))]
         #[pin]
         pub(super) stream: S,
     }

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -6,17 +6,17 @@ use tokio::sync::Mutex;
 ///
 /// Cloning this stream allocates a new channel for the new receiver, so that
 /// future copies of stream items are forwarded to the channel.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Educe)]
+#[educe(Debug)]
 pub struct Tee<T>
 where
     T: 'static,
 {
     pub(super) buf_size: Option<usize>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub(super) future: Arc<Mutex<Option<rt::JoinHandle<()>>>>,
     pub(super) sender_set: Weak<DashSet<ByAddress<Arc<flume::Sender<T>>>>>,
-    #[derivative(Debug = "ignore")]
+    #[educe(Debug(ignore))]
     pub(super) stream: flume::r#async::RecvStream<'static, T>,
 }
 

--- a/src/try_index_stream.rs
+++ b/src/try_index_stream.rs
@@ -78,8 +78,8 @@ mod try_reorder_enumerated {
     use super::*;
 
     /// Stream for the [try_reorder_enumerated()](TryIndexStreamExt::try_reorder_enumerated) method.
-    #[derive(Derivative)]
-    #[derivative(Debug)]
+    #[derive(Educe)]
+    #[educe(Debug(bound(T: Debug, E: Debug)))]
     #[pin_project]
     pub struct TryReorderEnumerated<S, T, E>
     where
@@ -91,7 +91,7 @@ mod try_reorder_enumerated {
         pub(super) buffer: HashMap<usize, T>,
         pub(super) _phantom: PhantomData<E>,
         #[pin]
-        #[derivative(Debug = "ignore")]
+        #[educe(Debug(ignore))]
         pub(super) stream: S,
     }
 

--- a/src/try_stream.rs
+++ b/src/try_stream.rs
@@ -278,8 +278,8 @@ mod try_enumerate {
     use super::*;
 
     /// Stream for the [try_enumerate()](crate::try_stream::TryStreamExt::try_enumerate) method.
-    #[derive(Derivative)]
-    #[derivative(Debug)]
+    #[derive(Educe)]
+    #[educe(Debug)]
     #[pin_project]
     pub struct TryEnumerate<S, T, E>
     where
@@ -289,7 +289,7 @@ mod try_enumerate {
         pub(super) fused: bool,
         pub(super) _phantom: PhantomData<(T, E)>,
         #[pin]
-        #[derivative(Debug = "ignore")]
+        #[educe(Debug(ignore))]
         pub(super) stream: S,
     }
 


### PR DESCRIPTION
This (almost) completely removes any dependency on the legacy version of `syn`,
it required:

1. Replacing `derivative`, which is essentially unmaintained, with `educe`.
2. Replacing `structopt` with `clap` in the examples.

I also did a drive-by update of `flume` and `itertools` which required no code
changes.

Note that `syn 1` is still referenced in the lockfile due to `async-std`, where
the dependency cannot be easily removed.
